### PR TITLE
fixed null username error

### DIFF
--- a/api/src/main/java/ovh/mythmc/banco/api/accounts/service/AbstractLocalUUIDResolver.java
+++ b/api/src/main/java/ovh/mythmc/banco/api/accounts/service/AbstractLocalUUIDResolver.java
@@ -37,9 +37,9 @@ public abstract class AbstractLocalUUIDResolver implements LocalUUIDResolver {
     @Override
     public @NotNull Optional<UUID> resolve(@NotNull String username) {
         return Set.copyOf(offlinePlayers).stream()
-            .filter(offlinePlayer -> offlinePlayer.name().equals(username))
-            .map(OfflinePlayerReference::uuid)
-            .findAny();
+                .filter(offlinePlayer -> username.equals(offlinePlayer.name()))
+                .map(OfflinePlayerReference::uuid)
+                .findAny();
     }
 
     @Override


### PR DESCRIPTION
the plugin sometimes throws an error when checking for offlineplayer usernames (as published on the discord banco-support channel)

this simple fix prevents that from happening